### PR TITLE
Json extraction - look for the last ';' instead of the first one

### DIFF
--- a/pyonwater/client.py
+++ b/pyonwater/client.py
@@ -114,7 +114,7 @@ class Client:
     def extract_json(self, line: str, prefix: str) -> list[dict[str, Any]]:
         """Extract JSON response."""
         line = line[line.find(prefix) + len(prefix) :]
-        line = line[: line.find(";")]
+        line = line[: line.rfind(";")]
         return json.loads(line)  # type: ignore
 
     @property


### PR DESCRIPTION
My address has a ';' in it in the eyeonwater system, and this string slicing fails. Looking for the last ';' would work better, so we get the end of the javascript line instead of a random string slice ending in the middle of the address, that later fails the json decoding.