### PR TITLE
Feat: Add support for '10 CF' unit

### DIFF
--- a/pyonwater/models/units.py
+++ b/pyonwater/models/units.py
@@ -12,6 +12,7 @@ class EOWUnits(str, Enum):
     UNIT_100_GAL = "100 GAL"
     UNIT_10_GAL = "10 GAL"
     UNIT_CF = "CF"
+    UNIT_10_CF = "10 CF"
     UNIT_CUBIC_FEET = "CUBIC_FEET"
     UNIT_CCF = "CCF"
     UNIT_KGAL = "KGAL"


### PR DESCRIPTION
Adds support for the '10 CF' billing unit to the EOWUnits enum.

This unit is used by some utilities, such as the City of Manteca, and is necessary to prevent a `ValidationError` when parsing meter data for affected users.