### PR TITLE
Prefer new_search meter discovery with dashboard fallback

### DIFF
--- a/pyonwater/account.py
+++ b/pyonwater/account.py
@@ -1,6 +1,7 @@
 """EyeOnWater API integration."""
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 import urllib.parse
 
@@ -12,6 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .client import Client
 
 DASHBOARD_ENDPOINT = "/dashboard/"
+NEW_SEARCH_ENDPOINT = "/api/2/residential/new_search"
 METER_UUID_FIELD = "meter_uuid"
 METER_ID_FIELD = "meter_id"
 INFO_PREFIX = "AQ.Views.MeterPicker.meters = "
@@ -33,6 +35,10 @@ class Account:
 
     async def fetch_meter_readers(self, client: Client) -> list[MeterReader]:
         """List the meter readers associated with the account."""
+        meters = await self._fetch_meter_readers_new_search(client)
+        if meters:
+            return meters
+
         path = DASHBOARD_ENDPOINT + urllib.parse.quote(self.username)
         data = await client.request(path=path, method="get")
 
@@ -56,6 +62,44 @@ class Account:
                         meter_id=meter_id,
                     )
                     meters.append(meter)
+
+        return meters
+
+    async def _fetch_meter_readers_new_search(self, client: Client) -> list[MeterReader]:
+        """Fetch meters using the API endpoint used by modern EyeOnWater flows."""
+        try:
+            raw = await client.request(
+                path=NEW_SEARCH_ENDPOINT,
+                method="post",
+                json={"query": {"match_all": {}}},
+            )
+            payload = json.loads(raw)
+        except (EyeOnWaterAPIError, json.JSONDecodeError, TypeError, ValueError):
+            return []
+
+        hits = payload.get("elastic_results", {}).get("hits", {}).get("hits", [])
+        meters: list[MeterReader] = []
+        for hit in hits:
+            source = hit.get("_source", {})
+            meter_obj = source.get("meter", {})
+            if not isinstance(meter_obj, dict):
+                meter_obj = {}
+
+            meter_uuid = (
+                meter_obj.get("meter_uuid")
+                or source.get(METER_UUID_FIELD)
+                or source.get("meter.meter_uuid")
+                or hit.get("_id")
+            )
+            meter_id = (
+                meter_obj.get("meter_id")
+                or source.get(METER_ID_FIELD)
+                or source.get("meter.meter_id")
+            )
+            if not meter_uuid or not meter_id:
+                continue
+
+            meters.append(MeterReader(meter_uuid=meter_uuid, meter_id=str(meter_id)))
 
         return meters
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyonwater"
-version = "0.3.22"
+version = "0.3.23"
 description = "EyeOnWater client library."
 authors = []
 license = "MIT"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -190,3 +190,61 @@ async def test_client_missing_meter_uuid(aiohttp_client, loop):
 
     with pytest.raises(EyeOnWaterAPIError):
         await account.fetch_meter_readers(client=client)
+
+
+async def test_client_new_search_nested_meter_payload(aiohttp_client, loop):
+    """Test parsing nested meter fields from new_search payload."""
+
+    async def mock_new_search_nested(request):
+        data = (
+            "{\"elastic_results\": {\"hits\": {\"hits\": ["
+            "{\"_id\": \"fallback_uuid\", \"_source\": {\"meter\": {\"meter_uuid\": \"nested_uuid\", \"meter_id\": 12345}}}"
+            "]}}}"
+        )
+        return web.Response(text=data)
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/new_search", mock_new_search_nested)
+    websession = await aiohttp_client(app)
+
+    account = Account(
+        eow_hostname="",
+        username="user",
+        password="",
+    )
+
+    client = Client(websession=websession, account=account)
+    await client.authenticate()
+
+    readers = await account.fetch_meter_readers(client=client)
+    assert len(readers) == 1
+    assert readers[0].meter_uuid == "nested_uuid"
+    assert readers[0].meter_id == "12345"
+
+
+async def test_client_falls_back_to_dashboard_when_new_search_empty(aiohttp_client, loop):
+    """Test dashboard fallback when new_search has no parseable meters."""
+
+    async def mock_new_search_empty(request):
+        return web.Response(text="{\"elastic_results\": {\"hits\": {\"hits\": []}}}")
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/new_search", mock_new_search_empty)
+    app.router.add_get("/dashboard/user", mock_get_meters_endpoint)
+    websession = await aiohttp_client(app)
+
+    account = Account(
+        eow_hostname="",
+        username="user",
+        password="",
+    )
+
+    client = Client(websession=websession, account=account)
+    await client.authenticate()
+
+    readers = await account.fetch_meter_readers(client=client)
+    assert len(readers) == 1
+    assert readers[0].meter_uuid == "123"
+    assert readers[0].meter_id == "456"


### PR DESCRIPTION
  ## Summary
  This change makes meter discovery more reliable by preferring the JSON API endpoint used by modern EyeOnWater flows,
  while preserving compatibility via existing dashboard parsing fallback.

  ## Changes
  - `Account.fetch_meter_readers` now:
    - tries `/api/2/residential/new_search` first
    - falls back to dashboard HTML parsing if no usable meters are found
  - Added tests:
    - nested `new_search` payload parsing (`_source.meter.meter_uuid`, `_source.meter.meter_id`)
    - fallback to dashboard parsing when `new_search` returns no meters

  ## Why
  In some environments, dashboard scraping can be brittle. The API response is more structured and stable, but fallback
  keeps existing behavior intact.

  ## Notes
  - Scope intentionally limited to meter discovery and tests only.
  - No behavior changes to meter reading/history logic in this PR.
