### PR TITLE
Add leak model fields and extended DataPoint metadata

### DIFF
--- a/pyonwater/meter.py
+++ b/pyonwater/meter.py
@@ -106,6 +106,15 @@ class Meter:
         native_reading = convert_to_native(
             self._native_unit_of_measurement, EOWUnits(dp.unit), dp.reading
         )
+        native_flow_value = None
+        if dp.flow_value is not None:
+            native_flow_value = convert_to_native(
+                self._native_unit_of_measurement, EOWUnits(dp.unit), dp.flow_value
+            )
         return DataPoint(
-            dt=dp.dt, reading=native_reading, unit=self._native_unit_of_measurement
+            dt=dp.dt,
+            reading=native_reading,
+            unit=self._native_unit_of_measurement,
+            flow_value=native_flow_value,
+            end_dt=dp.end_dt,
         )

--- a/pyonwater/models/eow_models.py
+++ b/pyonwater/models/eow_models.py
@@ -118,6 +118,15 @@ class Notes(BaseModel):
     count: Optional[int] = None
 
 
+class LeakStatus(BaseModel):
+    # Optional fields
+    rate: Optional[float] = None
+    max_flow_rate: Optional[float] = None
+    received_time: Optional[datetime] = None
+    total_leak_24hrs: Optional[float] = None
+    time: Optional[datetime] = None
+
+
 class Flow(BaseModel):
     # Optional fields
     this_week: Optional[float] = None
@@ -190,6 +199,7 @@ class MeterData(BaseModel):
     flow: Optional[Flow] = None
     longitude: Optional[str] = None
     flags: Optional[ActiveFlags] = None
+    leak: Optional["LeakStatus"] = None
     model: Optional[str] = None
     sequence_number: Optional[int] = None
 
@@ -279,6 +289,7 @@ class Reading(BaseModel):
     latest_read: LatestRead
 
     # Optional fields
+    leak: Optional["LeakStatus"] = None
     battery: Optional[Battery] = None
     customer_uuid: Optional[str] = None
     aggregation_seconds: Optional[int] = None
@@ -385,6 +396,7 @@ class MeterInfo(BaseModel):
     reading: Reading = Field(..., alias="register_0")
 
     # Optional fields
+    leak: Optional[LeakStatus] = None
     sensors: Optional[Sensors] = None
     utility: Optional[Utility] = None
     updated: Optional[int] = None

--- a/pyonwater/models/models.py
+++ b/pyonwater/models/models.py
@@ -16,3 +16,5 @@ class DataPoint:
     dt: datetime
     reading: float
     unit: str
+    flow_value: float | None = None
+    end_dt: datetime | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyonwater"
-version = "0.3.23"
+version = "0.3.24"
 description = "EyeOnWater client library."
 authors = []
 license = "MIT"

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -1,6 +1,8 @@
 """Tests for pyonwater meter."""
 
 
+from datetime import datetime, timedelta, timezone
+
 from aiohttp import web
 from conftest import (
     build_client,
@@ -13,7 +15,13 @@ from conftest import (
 )
 import pytest
 
-from pyonwater import EOWUnits, EyeOnWaterException, EyeOnWaterUnitError, NativeUnits
+from pyonwater import (
+    DataPoint,
+    EOWUnits,
+    EyeOnWaterException,
+    EyeOnWaterUnitError,
+    NativeUnits,
+)
 
 """Mock for historical data request, but no actual data"""
 mock_historical_data_nodata_endpoint = build_data_endpoint(
@@ -245,3 +253,30 @@ async def test_meter_historical_same_date_more_data(aiohttp_client, loop):
     await meter.read_historical_data(client=client2, days_to_load=1)
     # The moredata mock has 2 entries, should replace
     assert len(meter.last_historical_data) >= 1
+
+
+async def test_meter_convert_to_native_preserves_flow_and_end_dt(aiohttp_client, loop):
+    """Test flow_value conversion and end_dt passthrough on DataPoint conversion."""
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/new_search", mock_read_meter_endpoint)
+    websession = await aiohttp_client(app)
+
+    account, client = await build_client(websession)
+    meter = await build_meter(client)
+
+    start_dt = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    end_dt = start_dt + timedelta(hours=1)
+    converted = meter._convert_to_native(
+        DataPoint(
+            dt=start_dt,
+            reading=1.0,
+            unit=EOWUnits.UNIT_100_GAL,
+            flow_value=2.0,
+            end_dt=end_dt,
+        )
+    )
+
+    assert converted.reading == 100.0
+    assert converted.flow_value == 200.0
+    assert converted.end_dt == end_dt

--- a/tests/test_models_extensions.py
+++ b/tests/test_models_extensions.py
@@ -1,0 +1,44 @@
+"""Tests for additional model fields."""
+
+from pyonwater.models import MeterInfo
+
+
+def test_meter_info_parses_leak_fields() -> None:
+    """Test leak fields parse for top-level, meter, and reading payloads."""
+    payload = {
+        "register_0": {
+            "flags": {
+                "EmptyPipe": False,
+                "Leak": False,
+                "CoverRemoved": False,
+                "Tamper": False,
+                "ReverseFlow": False,
+                "LowBattery": False,
+                "BatteryCharging": False,
+            },
+            "latest_read": {
+                "full_read": 1.0,
+                "units": "gal",
+                "read_time": "2026-02-01T00:00:00Z",
+            },
+            "leak": {
+                "rate": 1.2,
+                "max_flow_rate": 3.4,
+                "total_leak_24hrs": 5.6,
+                "time": "2026-02-01T01:00:00Z",
+                "received_time": "2026-02-01T01:01:00Z",
+            },
+        },
+        "meter": {"leak": {"rate": 0.7, "max_flow_rate": 0.9}},
+        "leak": {"rate": 2.2, "total_leak_24hrs": 9.9},
+    }
+
+    model = MeterInfo.model_validate(payload)
+
+    assert model.leak is not None
+    assert model.leak.rate == 2.2
+    assert model.meter is not None
+    assert model.meter.leak is not None
+    assert model.meter.leak.max_flow_rate == 0.9
+    assert model.reading.leak is not None
+    assert model.reading.leak.total_leak_24hrs == 5.6


### PR DESCRIPTION
## Summary
- Extend DataPoint with optional flow_value and end_dt
- Preserve and convert flow_value, and preserve end_dt in meter native conversion
- Add optional LeakStatus fields to MeterInfo, Reading, and MeterData
- Add focused tests for the new fields

## Why
This is a narrow follow-up after PR #47 to expose data already present in EyeOnWater payloads without changing request or transport behavior.

## Tests
- Added tests/test_models_extensions.py
- Added test_meter_convert_to_native_preserves_flow_and_end_dt in tests/test_meter.py

Note: test execution could not be completed in this environment because pytest is not installed in the local Python toolchain.