### PR TITLE
Add export-range historical data support

### DIFF
--- a/pyonwater/meter_reader.py
+++ b/pyonwater/meter_reader.py
@@ -98,7 +98,7 @@ class MeterReader:
             msg = f"days_to_load must be at least 1, got {days_to_load}"
             raise ValueError(msg)
 
-        today = datetime.datetime.now().replace(
+        today = datetime.datetime.now(tz=pytz.UTC).replace(
             hour=0,
             minute=0,
             second=0,
@@ -294,13 +294,21 @@ class MeterReader:
         include_today: bool = True,
         export_resolution: str = "hourly",
         export_unit: str = "Gallons",
+        max_retries: int = 30,
+        poll_interval: float = 2.0,
     ) -> list[DataPoint]:
         """Retrieve historical data via the export range API."""
         if days_to_load < 1:
             msg = f"days_to_load must be at least 1, got {days_to_load}"
             raise ValueError(msg)
+        if max_retries < 1:
+            msg = f"max_retries must be at least 1, got {max_retries}"
+            raise ValueError(msg)
+        if poll_interval < 0:
+            msg = f"poll_interval must be non-negative, got {poll_interval}"
+            raise ValueError(msg)
 
-        today = datetime.datetime.now().replace(
+        today = datetime.datetime.now(tz=pytz.UTC).replace(
             hour=0,
             minute=0,
             second=0,
@@ -332,7 +340,7 @@ class MeterReader:
         )
         try:
             payload = json.loads(raw)
-        except Exception as exc:
+        except (json.JSONDecodeError, ValueError) as exc:
             msg = f"Unexpected export initiate response: {raw[:200]}"
             raise EyeOnWaterAPIError(msg) from exc
 
@@ -340,11 +348,16 @@ class MeterReader:
         if not task_id:
             msg = f"Export task id not found in response: {payload}"
             raise EyeOnWaterAPIError(msg)
+        _LOGGER.debug(
+            "Initiated export for meter %s with task_id %s",
+            self.meter_uuid,
+            task_id,
+        )
 
         status: dict[str, Any] | None = None
-        for attempt in range(40):
+        for attempt in range(max_retries):
             if attempt:
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(poll_interval)
             status_raw = await client.request(
                 path=f"{EXPORT_STATUS_ENDPOINT}{task_id}",
                 method="get",
@@ -352,11 +365,18 @@ class MeterReader:
             )
             try:
                 status = json.loads(status_raw)
-            except Exception:
+            except (json.JSONDecodeError, ValueError):
                 status = None
+            state = status.get("state") if isinstance(status, dict) else None
+            _LOGGER.debug(
+                "Export poll %d/%d for task %s returned state %s",
+                attempt + 1,
+                max_retries,
+                task_id,
+                state,
+            )
             if not status:
                 continue
-            state = status.get("state")
             if state == "done":
                 break
             if state == "error":
@@ -371,7 +391,7 @@ class MeterReader:
         if isinstance(result, str):
             try:
                 result = json.loads(result)
-            except Exception:
+            except (json.JSONDecodeError, ValueError):
                 result = None
         if not isinstance(result, dict) or "url" not in result:
             msg = f"Export result missing URL: {status}"
@@ -379,7 +399,10 @@ class MeterReader:
 
         export_path = self._normalize_export_path(result["url"])
         raw_csv = await client.request(path=export_path, method="get")
-        return self._parse_export_csv(raw_csv)
+        _LOGGER.debug("Downloaded export CSV for task %s: %d bytes", task_id, len(raw_csv))
+        points = self._parse_export_csv(raw_csv)
+        _LOGGER.debug("Parsed %d export data points for task %s", len(points), task_id)
+        return points
 
     @staticmethod
     def _normalize_export_path(export_url: str) -> str:
@@ -416,7 +439,8 @@ class MeterReader:
                 timezone = pytz.timezone(timezone_name)
                 reading = float(read_value)
                 flow = float(flow_value) if flow_value not in (None, "") else None
-            except Exception:
+            except (ValueError, KeyError, pytz.UnknownTimeZoneError):
+                _LOGGER.warning("Skipping unparseable CSV row: %s", row)
                 continue
             points.append(
                 DataPoint(
@@ -442,4 +466,4 @@ class MeterReader:
             return datetime.datetime.fromisoformat(value)
         except ValueError as exc:
             msg = f"Unrecognized export datetime: {value}"
-            raise EyeOnWaterAPIError(msg) from exc
+            raise ValueError(msg) from exc

--- a/pyonwater/meter_reader.py
+++ b/pyonwater/meter_reader.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import csv
 import datetime
 import json
 import logging
+import time
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlparse
 
 from pydantic import ValidationError
 import pytz
@@ -20,6 +23,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 SEARCH_ENDPOINT = "/api/2/residential/new_search"
 CONSUMPTION_ENDPOINT = "/api/2/residential/consumption?eow=True"
+EXPORT_INIT_ENDPOINT = "/reports/export_initiate"
+EXPORT_STATUS_ENDPOINT = "/reports/export_check_status/"
 
 # Fallback units when the caller does not specify a preference.
 DEFAULT_REQUEST_UNITS = "cm"
@@ -280,3 +285,161 @@ class MeterReader:
 
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self.convert, data, key)
+
+    async def read_historical_data_range_export(
+        self,
+        client: Client,
+        days_to_load: int,
+        *,
+        include_today: bool = True,
+        export_resolution: str = "hourly",
+        export_unit: str = "Gallons",
+    ) -> list[DataPoint]:
+        """Retrieve historical data via the export range API."""
+        if days_to_load < 1:
+            msg = f"days_to_load must be at least 1, got {days_to_load}"
+            raise ValueError(msg)
+
+        today = datetime.datetime.now().replace(
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+        if include_today:
+            end_date = today
+            start_date = today - datetime.timedelta(days=max(days_to_load - 1, 0))
+        else:
+            end_date = today - datetime.timedelta(days=1)
+            start_date = end_date - datetime.timedelta(days=max(days_to_load - 1, 0))
+
+        params = {
+            "export_unit": export_unit,
+            "site": "residential",
+            "export_resolution": export_resolution,
+            "start-date": start_date.strftime("%m/%d/%Y"),
+            "end-date": end_date.strftime("%m/%d/%Y"),
+            "meter_uuid": self.meter_uuid,
+            "row-format": "range",
+            "export_all": "false",
+            "_": int(time.time() * 1000),
+        }
+
+        raw = await client.request(
+            path=EXPORT_INIT_ENDPOINT,
+            method="get",
+            params=params,
+        )
+        try:
+            payload = json.loads(raw)
+        except Exception as exc:
+            msg = f"Unexpected export initiate response: {raw[:200]}"
+            raise EyeOnWaterAPIError(msg) from exc
+
+        task_id = payload.get("task_id")
+        if not task_id:
+            msg = f"Export task id not found in response: {payload}"
+            raise EyeOnWaterAPIError(msg)
+
+        status: dict[str, Any] | None = None
+        for attempt in range(40):
+            if attempt:
+                await asyncio.sleep(0.1)
+            status_raw = await client.request(
+                path=f"{EXPORT_STATUS_ENDPOINT}{task_id}",
+                method="get",
+                params={"_": int(time.time() * 1000)},
+            )
+            try:
+                status = json.loads(status_raw)
+            except Exception:
+                status = None
+            if not status:
+                continue
+            state = status.get("state")
+            if state == "done":
+                break
+            if state == "error":
+                msg = status.get("message", "Export task error")
+                raise EyeOnWaterAPIError(msg)
+
+        if not status or status.get("state") != "done":
+            msg = f"Export task did not complete: {status}"
+            raise EyeOnWaterAPIError(msg)
+
+        result = status.get("result")
+        if isinstance(result, str):
+            try:
+                result = json.loads(result)
+            except Exception:
+                result = None
+        if not isinstance(result, dict) or "url" not in result:
+            msg = f"Export result missing URL: {status}"
+            raise EyeOnWaterAPIError(msg)
+
+        export_path = self._normalize_export_path(result["url"])
+        raw_csv = await client.request(path=export_path, method="get")
+        return self._parse_export_csv(raw_csv)
+
+    @staticmethod
+    def _normalize_export_path(export_url: str) -> str:
+        """Normalize export URLs into a request path."""
+        if export_url.startswith("/"):
+            return export_url
+        if export_url.startswith(("http://", "https://")):
+            parsed = urlparse(export_url)
+            if parsed.path:
+                path = parsed.path
+                if parsed.query:
+                    path = f"{path}?{parsed.query}"
+                return path
+        msg = f"Unsupported export url format: {export_url}"
+        raise EyeOnWaterAPIError(msg)
+
+    def _parse_export_csv(self, raw_csv: str) -> list[DataPoint]:
+        """Parse range export CSV into data points."""
+        if not raw_csv:
+            return []
+
+        reader = csv.DictReader(raw_csv.splitlines())
+        points: list[DataPoint] = []
+        for row in reader:
+            read_time = row.get("Read_Time") or row.get("Read Time")
+            timezone_name = row.get("Timezone") or "UTC"
+            read_value = row.get("Read")
+            read_unit = row.get("Read_Unit") or row.get("Read Unit") or row.get("Unit")
+            flow_value = row.get("Flow")
+            if not read_time or read_value is None or not read_unit:
+                continue
+            try:
+                dt_value = self._parse_export_datetime(read_time)
+                timezone = pytz.timezone(timezone_name)
+                reading = float(read_value)
+                flow = float(flow_value) if flow_value not in (None, "") else None
+            except Exception:
+                continue
+            points.append(
+                DataPoint(
+                    dt=timezone.localize(dt_value),
+                    reading=reading,
+                    unit=read_unit,
+                    flow_value=flow,
+                )
+            )
+
+        points.sort(key=lambda d: d.dt)
+        return points
+
+    @staticmethod
+    def _parse_export_datetime(value: str) -> datetime.datetime:
+        """Parse export timestamps with the formats observed in EOW exports."""
+        for fmt in ("%m/%d/%Y %H:%M", "%m/%d/%Y %I:%M %p"):
+            try:
+                return datetime.datetime.strptime(value, fmt)
+            except ValueError:
+                continue
+        try:
+            return datetime.datetime.fromisoformat(value)
+        except ValueError as exc:
+            msg = f"Unrecognized export datetime: {value}"
+            raise EyeOnWaterAPIError(msg) from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyonwater"
-version = "0.3.25"
+version = "0.3.26"
 description = "EyeOnWater client library."
 authors = []
 license = "MIT"

--- a/tests/test_meter_reader.py
+++ b/tests/test_meter_reader.py
@@ -3,6 +3,7 @@
 import json
 import logging
 from typing import Any
+from unittest.mock import patch
 
 from aiohttp import web
 from conftest import (
@@ -182,3 +183,80 @@ async def test_meter_reader_historical_invalid_json_raises(aiohttp_client: Any) 
 
     with pytest.raises(EyeOnWaterAPIError):  # nosec: B101
         await reader.read_historical_data(client=client, days_to_load=1)
+
+
+@pytest.mark.asyncio()
+async def test_meter_reader_range_export(aiohttp_client: Any) -> None:
+    """Verify export-range polling and CSV parsing."""
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+
+    async def mock_export_initiate(request: web.Request) -> web.Response:
+        assert request.query["meter_uuid"] == "meter_uuid"  # nosec: B101
+        assert request.query["row-format"] == "range"  # nosec: B101
+        return web.Response(text='{"task_id":"task-123"}')
+
+    poll_count = 0
+
+    async def mock_export_status(_request: web.Request) -> web.Response:
+        nonlocal poll_count
+        poll_count += 1
+        if poll_count == 1:
+            return web.Response(text='{"state":"queued"}')
+        return web.Response(
+            text=json.dumps(
+                {
+                    "state": "done",
+                    "result": {
+                        "url": "https://eyeonwater.com/export/download.csv?token=abc"
+                    },
+                }
+            )
+        )
+
+    async def mock_export_csv(_request: web.Request) -> web.Response:
+        return web.Response(
+            text=(
+                "Read_Time,Read,Read_Unit,Flow,Timezone\n"
+                "03/01/2026 1:15 PM,101.5,GAL,1.25,US/Pacific\n"
+                "03/01/2026 12:15 PM,100.0,GAL,,US/Pacific\n"
+            )
+        )
+
+    app.router.add_get("/reports/export_initiate", mock_export_initiate)
+    app.router.add_get(
+        "/reports/export_check_status/task-123",
+        mock_export_status,
+    )
+    app.router.add_get("/export/download.csv", mock_export_csv)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    with patch("pyonwater.meter_reader.asyncio.sleep") as sleep_mock:
+        data = await reader.read_historical_data_range_export(client=client, days_to_load=2)
+
+    assert len(data) == 2  # nosec: B101
+    assert [point.reading for point in data] == [100.0, 101.5]  # nosec: B101
+    assert data[0].flow_value is None  # nosec: B101
+    assert data[1].flow_value == 1.25  # nosec: B101
+    assert data[0].dt.tzinfo is not None  # nosec: B101
+    sleep_mock.assert_awaited_once_with(0.1)
+
+
+def test_normalize_export_path() -> None:
+    """Verify export URLs are converted into client request paths."""
+    assert (  # nosec: B101
+        MeterReader._normalize_export_path(
+            "https://eyeonwater.com/export/download.csv?token=abc"
+        )
+        == "/export/download.csv?token=abc"
+    )
+    assert MeterReader._normalize_export_path("/export/download.csv") == "/export/download.csv"  # nosec: B101
+
+
+def test_parse_export_datetime_invalid() -> None:
+    """Verify invalid export timestamps raise a clear error."""
+    with pytest.raises(EyeOnWaterAPIError, match="Unrecognized export datetime"):
+        MeterReader._parse_export_datetime("not-a-date")

--- a/tests/test_meter_reader.py
+++ b/tests/test_meter_reader.py
@@ -235,7 +235,11 @@ async def test_meter_reader_range_export(aiohttp_client: Any) -> None:
     reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
 
     with patch("pyonwater.meter_reader.asyncio.sleep") as sleep_mock:
-        data = await reader.read_historical_data_range_export(client=client, days_to_load=2)
+        data = await reader.read_historical_data_range_export(
+            client=client,
+            days_to_load=2,
+            poll_interval=0.1,
+        )
 
     assert len(data) == 2  # nosec: B101
     assert [point.reading for point in data] == [100.0, 101.5]  # nosec: B101
@@ -258,5 +262,22 @@ def test_normalize_export_path() -> None:
 
 def test_parse_export_datetime_invalid() -> None:
     """Verify invalid export timestamps raise a clear error."""
-    with pytest.raises(EyeOnWaterAPIError, match="Unrecognized export datetime"):
+    with pytest.raises(ValueError, match="Unrecognized export datetime"):
         MeterReader._parse_export_datetime("not-a-date")
+
+
+def test_parse_export_csv_skips_invalid_rows_with_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Verify malformed export rows are skipped with a warning."""
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+    raw_csv = (
+        "Read_Time,Read,Read_Unit,Flow,Timezone\n"
+        "03/01/2026 12:15 PM,100.0,GAL,,US/Pacific\n"
+        "not-a-date,101.5,GAL,1.25,US/Pacific\n"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pyonwater.meter_reader"):
+        points = reader._parse_export_csv(raw_csv)
+
+    assert len(points) == 1  # nosec: B101
+    assert points[0].reading == 100.0  # nosec: B101
+    assert "Skipping unparseable CSV row" in caplog.text  # nosec: B101


### PR DESCRIPTION
## Summary
- add export-range historical data retrieval via /reports/export_initiate and /reports/export_check_status/{task_id}
- normalize export URLs and parse CSV rows into DataPoint values
- add focused meter reader tests for export polling, URL normalization, and invalid timestamps
- bump version to 0.3.26

## Testing
- python -m pytest -q tests/test_meter_reader.py