### PR TITLE
fix: resolve pre-commit failures (black, ruff, mypy, codespell)

### DIFF
--- a/pyonwater/meter_reader.py
+++ b/pyonwater/meter_reader.py
@@ -354,6 +354,37 @@ class MeterReader:
             task_id,
         )
 
+        status = await self._poll_export_task(
+            client, task_id, max_retries, poll_interval
+        )
+
+        result = status.get("result")
+        if isinstance(result, str):
+            try:
+                result = json.loads(result)
+            except (json.JSONDecodeError, ValueError):
+                result = None
+        if not isinstance(result, dict) or "url" not in result:
+            msg = f"Export result missing URL: {status}"
+            raise EyeOnWaterAPIError(msg)
+
+        export_path = self._normalize_export_path(result["url"])
+        raw_csv = await client.request(path=export_path, method="get")
+        _LOGGER.debug(
+            "Downloaded export CSV for task %s: %d bytes", task_id, len(raw_csv)
+        )
+        points = self._parse_export_csv(raw_csv)
+        _LOGGER.debug("Parsed %d export data points for task %s", len(points), task_id)
+        return points
+
+    async def _poll_export_task(
+        self,
+        client: Client,
+        task_id: str,
+        max_retries: int,
+        poll_interval: float,
+    ) -> dict[str, Any]:
+        """Poll export task until done, error, or timeout."""
         status: dict[str, Any] | None = None
         for attempt in range(max_retries):
             if attempt:
@@ -378,31 +409,13 @@ class MeterReader:
             if not status:
                 continue
             if state == "done":
-                break
+                return status
             if state == "error":
                 msg = status.get("message", "Export task error")
                 raise EyeOnWaterAPIError(msg)
 
-        if not status or status.get("state") != "done":
-            msg = f"Export task did not complete: {status}"
-            raise EyeOnWaterAPIError(msg)
-
-        result = status.get("result")
-        if isinstance(result, str):
-            try:
-                result = json.loads(result)
-            except (json.JSONDecodeError, ValueError):
-                result = None
-        if not isinstance(result, dict) or "url" not in result:
-            msg = f"Export result missing URL: {status}"
-            raise EyeOnWaterAPIError(msg)
-
-        export_path = self._normalize_export_path(result["url"])
-        raw_csv = await client.request(path=export_path, method="get")
-        _LOGGER.debug("Downloaded export CSV for task %s: %d bytes", task_id, len(raw_csv))
-        points = self._parse_export_csv(raw_csv)
-        _LOGGER.debug("Parsed %d export data points for task %s", len(points), task_id)
-        return points
+        msg = f"Export task did not complete: {status}"
+        raise EyeOnWaterAPIError(msg)
 
     @staticmethod
     def _normalize_export_path(export_url: str) -> str:
@@ -438,9 +451,9 @@ class MeterReader:
                 dt_value = self._parse_export_datetime(read_time)
                 timezone = pytz.timezone(timezone_name)
                 reading = float(read_value)
-                flow = float(flow_value) if flow_value not in (None, "") else None
+                flow = float(flow_value) if flow_value not in (None, "") else None  # type: ignore[arg-type]
             except (ValueError, KeyError, pytz.UnknownTimeZoneError):
-                _LOGGER.warning("Skipping unparseable CSV row: %s", row)
+                _LOGGER.warning("Skipping unparsable CSV row: %s", row)
                 continue
             points.append(
                 DataPoint(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyonwater"
-version = "0.3.27"
+version = "0.3.28"
 description = "EyeOnWater client library."
 authors = []
 license = "MIT"

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -261,7 +261,9 @@ async def test_meter_historical_same_date_more_data(aiohttp_client: Any) -> None
     assert len(meter.last_historical_data) >= 1
 
 
-async def test_meter_range_export_converts_and_preserves_cache(aiohttp_client: Any) -> None:
+async def test_meter_range_export_converts_and_preserves_cache(
+    aiohttp_client: Any,
+) -> None:
     """Export wrapper converts values, forwards params, and leaves cache unchanged."""
     app = web.Application()
     app.router.add_post("/account/signin", mock_signin_endpoint)

--- a/tests/test_meter_reader.py
+++ b/tests/test_meter_reader.py
@@ -257,7 +257,10 @@ def test_normalize_export_path() -> None:
         )
         == "/export/download.csv?token=abc"
     )
-    assert MeterReader._normalize_export_path("/export/download.csv") == "/export/download.csv"  # nosec: B101
+    assert (
+        MeterReader._normalize_export_path("/export/download.csv")
+        == "/export/download.csv"
+    )  # nosec: B101
 
 
 def test_parse_export_datetime_invalid() -> None:
@@ -266,7 +269,9 @@ def test_parse_export_datetime_invalid() -> None:
         MeterReader._parse_export_datetime("not-a-date")
 
 
-def test_parse_export_csv_skips_invalid_rows_with_warning(caplog: pytest.LogCaptureFixture) -> None:
+def test_parse_export_csv_skips_invalid_rows_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Verify malformed export rows are skipped with a warning."""
     reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
     raw_csv = (
@@ -280,4 +285,4 @@ def test_parse_export_csv_skips_invalid_rows_with_warning(caplog: pytest.LogCapt
 
     assert len(points) == 1  # nosec: B101
     assert points[0].reading == 100.0  # nosec: B101
-    assert "Skipping unparseable CSV row" in caplog.text  # nosec: B101
+    assert "Skipping unparsable CSV row" in caplog.text  # nosec: B101


### PR DESCRIPTION
## Summary
Fix all pre-commit hook failures introduced by PR #51 (which was merged while the pre-commit and coverage workflows were disabled).

## Changes
- **black**: wrap long lines in meter_reader.py and test_meter_reader.py
- **ruff C901**: extract _poll_export_task() to reduce cyclomatic complexity of read_historical_data_range_export (was 17, limit is 10)
- **mypy arg-type**: add type: ignore for float(flow_value) call (value is already guarded)
- **codespell**: unparseable to unparsable in source and test

## Context
The pre-commit and coverage CI workflows were disabled by GitHub due to 60 days of inactivity. They have now been re-enabled. These fixes ensure the codebase passes all pre-commit hooks.