### PR TITLE
fix: raise EyeOnWaterAPIError for non-200 responses

### DIFF
--- a/pyonwater/client.py
+++ b/pyonwater/client.py
@@ -16,9 +16,9 @@ from tenacity import (
 )
 
 from .exceptions import (
+    EyeOnWaterAPIError,
     EyeOnWaterAuthError,
     EyeOnWaterAuthExpired,
-    EyeOnWaterException,
     EyeOnWaterRateLimitError,
 )
 
@@ -110,7 +110,7 @@ class Client:
                 self._truncate_payload(data),
             )
             msg = f"Request failed: {resp.status} {data}"
-            raise EyeOnWaterException(msg)
+            raise EyeOnWaterAPIError(msg)
 
         return data
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyonwater"
-version = "0.3.28"
+version = "0.3.29"
 description = "EyeOnWater client library."
 authors = []
 license = "MIT"


### PR DESCRIPTION
## Problem

Non-200 HTTP responses (e.g. 400 Bad Request) in \Client.request()\ raise the base \EyeOnWaterException\. This makes it impossible for callers (like the Home Assistant integration) to distinguish transient API errors from other exception types.

This was reported in [kdeyev/eyeonwater#168](https://github.com/kdeyev/eyeonwater/issues/168) — the EyeOnWater API intermittently returns 400 errors, and the integration couldn't catch them specifically to trigger HA's auto-retry mechanism.

## Fix

Change \client.py\ line 113 to raise \EyeOnWaterAPIError\ (a subclass of \EyeOnWaterException\) instead of the base class.

This is a **non-breaking change** — any code catching \EyeOnWaterException\ will still work since \EyeOnWaterAPIError\ inherits from it.