### PR TITLE
fix: enforce token expiration and remove _id UUID fallback

### DIFF
--- a/pyonwater/account.py
+++ b/pyonwater/account.py
@@ -120,7 +120,6 @@ class Account:
                 meter_obj.get("meter_uuid")
                 or source.get(METER_UUID_FIELD)
                 or source.get("meter.meter_uuid")
-                or hit.get("_id")
             )
             meter_id: str | None = (
                 meter_obj.get("meter_id")

--- a/pyonwater/client.py
+++ b/pyonwater/client.py
@@ -151,7 +151,10 @@ class Client:
     @property
     def is_token_valid(self) -> bool:
         """Validate the token."""
-        if self.authenticated or (datetime.datetime.now() < self.token_expiration):
-            return True
-
-        return False
+        if not self.authenticated:
+            return False
+        try:
+            return datetime.datetime.now() < self.token_expiration
+        except TypeError:
+            # naive vs aware datetime comparison; treat as expired
+            return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyonwater"
-version = "0.3.30"
+version = "0.3.31"
 description = "EyeOnWater client library."
 authors = []
 license = "MIT"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -343,3 +343,52 @@ async def test_client_falls_back_to_dashboard_when_new_search_empty(
     assert len(readers) == 1  # nosec: B101
     assert readers[0].meter_uuid == "123"  # nosec: B101
     assert readers[0].meter_id == "456"  # nosec: B101
+
+
+@pytest.mark.asyncio()
+async def test_client_token_expires_after_timeout(aiohttp_client: Any) -> None:
+    """Token should be re-fetched after expiration period."""
+    import datetime
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    websession = await aiohttp_client(app)
+
+    account = Account(eow_hostname="", username="user", password="")  # nosec: B106
+    client = Client(websession=websession, account=account)
+
+    await client.authenticate()
+    assert client.is_token_valid  # nosec: B101
+
+    # Simulate token expiration
+    client.token_expiration = datetime.datetime.now() - datetime.timedelta(minutes=1)
+    assert not client.is_token_valid  # nosec: B101
+
+    # Re-authenticate should succeed
+    await client.authenticate()
+    assert client.is_token_valid  # nosec: B101
+
+
+@pytest.mark.asyncio()
+async def test_client_new_search_ignores_id_as_uuid(aiohttp_client: Any) -> None:
+    """Meters without a real meter_uuid should be skipped, not use _id as fallback."""
+
+    async def mock_new_search_id_only(_request: web.Request) -> web.Response:
+        data = (
+            '{"elastic_results": {"hits": {"hits": ['
+            '{"_id": "es_doc_id", "_source": {"meter_id": "456"}}'
+            "]}}}"
+        )
+        return web.Response(text=data)
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/new_search", mock_new_search_id_only)
+    websession = await aiohttp_client(app)
+
+    account = Account(eow_hostname="", username="user", password="")  # nosec: B106
+    client = Client(websession=websession, account=account)
+    await client.authenticate()
+
+    readers = await account.fetch_meter_readers_new_search(client=client)
+    assert len(readers) == 0  # nosec: B101


### PR DESCRIPTION
Two fixes for historical data import reliability:

1. **Fix is_token_valid** — Previously used \or\ logic: once authenticated=True, the token was considered valid forever regardless of expiration. Now uses \nd\ so expired tokens trigger re-authentication. This likely caused historical imports to get empty responses when the session was stale (API returns empty/200 instead of 401).

2. **Remove _id fallback in new_search discovery** — The meter_uuid extraction fell back to \hit['_id']\ (Elasticsearch document ID) when the proper fields were missing. This is NOT a valid meter_uuid and causes downstream queries to return empty or 400. Removed the fallback so meters with missing UUIDs are properly skipped.

Bump version to 0.3.31.