### PR TITLE
chore: add debug logging to client and account

### DIFF
--- a/pyonwater/account.py
+++ b/pyonwater/account.py
@@ -13,6 +13,10 @@ from .meter_reader import MeterReader
 if TYPE_CHECKING:  # pragma: no cover
     from .client import Client
 
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
 DASHBOARD_ENDPOINT = "/dashboard/"
 NEW_SEARCH_ENDPOINT = "/api/2/residential/new_search"
 METER_UUID_FIELD = "meter_uuid"
@@ -50,14 +54,28 @@ class Account:
                 new_search.
         """
         if prefer_new_search:
+            _LOGGER.debug("Discovery: trying new_search first")
             new_search_meters = await self.fetch_meter_readers_new_search(client)
             if new_search_meters:
+                _LOGGER.debug(
+                    "Discovery: new_search found %d meter(s)", len(new_search_meters)
+                )
                 return new_search_meters
+            _LOGGER.debug(
+                "Discovery: new_search returned nothing, falling back to dashboard"
+            )
             return await self._fetch_meter_readers_dashboard(client)
 
+        _LOGGER.debug("Discovery: trying dashboard first")
         dashboard_meters = await self._fetch_meter_readers_dashboard(client)
         if dashboard_meters:
+            _LOGGER.debug(
+                "Discovery: dashboard found %d meter(s)", len(dashboard_meters)
+            )
             return dashboard_meters
+        _LOGGER.debug(
+            "Discovery: dashboard returned nothing, falling back to new_search"
+        )
         return await self.fetch_meter_readers_new_search(client)
 
     async def _fetch_meter_readers_dashboard(self, client: Client) -> list[MeterReader]:

--- a/pyonwater/client.py
+++ b/pyonwater/client.py
@@ -82,6 +82,7 @@ class Client:
     ) -> str:
         """Make API calls against the eow API."""
         await self.authenticate()
+        _LOGGER.debug("%s %s", method.upper(), path)
         resp = await self.websession.request(
             method,
             f"{self.base_url}{path}",
@@ -100,6 +101,7 @@ class Client:
             raise EyeOnWaterAuthExpired
 
         self._update_token_expiration()
+        _LOGGER.debug("Response: %s (%d bytes)", resp.status, resp.content_length or 0)
 
         data: str = await resp.text()
 
@@ -117,7 +119,10 @@ class Client:
     async def authenticate(self) -> None:
         """Authenticate the client."""
         if not self.is_token_valid:
-            _LOGGER.debug("Requesting login token")
+            _LOGGER.debug(
+                "Token expired (authenticated=%s), re-authenticating",
+                self.authenticated,
+            )
 
             resp = await self.websession.request(
                 "POST",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyonwater"
-version = "0.3.31"
+version = "0.3.32"
 description = "EyeOnWater client library."
 authors = []
 license = "MIT"


### PR DESCRIPTION
Add diagnostic logging that would help debug issues like #168:

**client.py:**
- Log request method and path before each API call
- Log response status code and body size on success
- Log reason for re-authentication (token expired vs not authenticated)

**account.py:**
- Add logger to module (previously had zero logging)
- Log which discovery method is tried first and fallback transitions
- Log number of meters found by each method