### PR TITLE
test: expand coverage for export-range, client, models, and units

### DIFF
--- a/pyonwater/meter_reader.py
+++ b/pyonwater/meter_reader.py
@@ -321,7 +321,7 @@ class MeterReader:
             end_date = today - datetime.timedelta(days=1)
             start_date = end_date - datetime.timedelta(days=max(days_to_load - 1, 0))
 
-        params = {
+        params: dict[str, str | int] = {
             "export_unit": export_unit,
             "site": "residential",
             "export_resolution": export_resolution,
@@ -368,12 +368,12 @@ class MeterReader:
             msg = f"Export result missing URL: {status}"
             raise EyeOnWaterAPIError(msg)
 
-        export_path = self._normalize_export_path(result["url"])
+        export_path = self.normalize_export_path(cast(str, result["url"]))
         raw_csv = await client.request(path=export_path, method="get")
         _LOGGER.debug(
             "Downloaded export CSV for task %s: %d bytes", task_id, len(raw_csv)
         )
-        points = self._parse_export_csv(raw_csv)
+        points = self.parse_export_csv(raw_csv)
         _LOGGER.debug("Parsed %d export data points for task %s", len(points), task_id)
         return points
 
@@ -418,7 +418,7 @@ class MeterReader:
         raise EyeOnWaterAPIError(msg)
 
     @staticmethod
-    def _normalize_export_path(export_url: str) -> str:
+    def normalize_export_path(export_url: str) -> str:
         """Normalize export URLs into a request path."""
         if export_url.startswith("/"):
             return export_url
@@ -432,7 +432,7 @@ class MeterReader:
         msg = f"Unsupported export url format: {export_url}"
         raise EyeOnWaterAPIError(msg)
 
-    def _parse_export_csv(self, raw_csv: str) -> list[DataPoint]:
+    def parse_export_csv(self, raw_csv: str) -> list[DataPoint]:
         """Parse range export CSV into data points."""
         if not raw_csv:
             return []
@@ -448,10 +448,13 @@ class MeterReader:
             if not read_time or read_value is None or not read_unit:
                 continue
             try:
-                dt_value = self._parse_export_datetime(read_time)
+                dt_value = self.parse_export_datetime(read_time)
                 timezone = pytz.timezone(timezone_name)
                 reading = float(read_value)
-                flow = float(flow_value) if flow_value not in (None, "") else None  # type: ignore[arg-type]
+                flow_str = (
+                    flow_value if isinstance(flow_value, str) and flow_value else None
+                )
+                flow = float(flow_str) if flow_str is not None else None
             except (ValueError, KeyError, pytz.UnknownTimeZoneError):
                 _LOGGER.warning("Skipping unparsable CSV row: %s", row)
                 continue
@@ -468,7 +471,7 @@ class MeterReader:
         return points
 
     @staticmethod
-    def _parse_export_datetime(value: str) -> datetime.datetime:
+    def parse_export_datetime(value: str) -> datetime.datetime:
         """Parse export timestamps with the formats observed in EOW exports."""
         for fmt in ("%m/%d/%Y %H:%M", "%m/%d/%Y %I:%M %p"):
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyonwater"
-version = "0.3.32"
+version = "0.3.33"
 description = "EyeOnWater client library."
 authors = []
 license = "MIT"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,9 @@
 """Tests for pyonwater client."""  # nosec: B101, B106
 
+import datetime
+import json
 from typing import Any
+from unittest.mock import MagicMock
 
 from aiohttp import web
 from conftest import (
@@ -345,28 +348,111 @@ async def test_client_falls_back_to_dashboard_when_new_search_empty(
     assert readers[0].meter_id == "456"  # nosec: B101
 
 
+# KNOWN BUG: _fetch_meter_readers_dashboard raises an unhandled KeyError when a meter
+# entry has meter_uuid but no meter_id (METER_ID_FIELD key). Fixing the bug is out of
+# scope; test coverage deferred until the bug is fixed.
+
+
 @pytest.mark.asyncio()
 async def test_client_token_expires_after_timeout(aiohttp_client: Any) -> None:
     """Token should be re-fetched after expiration period."""
-    import datetime
-
     app = web.Application()
     app.router.add_post("/account/signin", mock_signin_endpoint)
     websession = await aiohttp_client(app)
 
-    account = Account(eow_hostname="", username="user", password="")  # nosec: B106
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="user",
+        password="",
+    )
     client = Client(websession=websession, account=account)
 
     await client.authenticate()
     assert client.is_token_valid  # nosec: B101
 
-    # Simulate token expiration
     client.token_expiration = datetime.datetime.now() - datetime.timedelta(minutes=1)
     assert not client.is_token_valid  # nosec: B101
 
-    # Re-authenticate should succeed
     await client.authenticate()
     assert client.is_token_valid  # nosec: B101
+
+
+@pytest.mark.asyncio()
+async def test_new_search_non_json_response_returns_empty(aiohttp_client: Any) -> None:
+    """Non-JSON response from new_search is caught as JSONDecodeError → returns []."""
+
+    async def bad_json(_request: web.Request) -> web.Response:
+        return web.Response(text="not json at all")
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/new_search", bad_json)
+    websession = await aiohttp_client(app)
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="user",
+        password="pass",
+    )
+    client = Client(websession=websession, account=account)
+    await client.authenticate()
+
+    readers = await account.fetch_meter_readers_new_search(client)
+    assert readers == []  # nosec: B101
+
+
+@pytest.mark.asyncio()
+async def test_new_search_missing_elastic_results_returns_empty(
+    aiohttp_client: Any,
+) -> None:
+    """Response with no 'elastic_results' key → empty meters list."""
+
+    async def no_elastic(_request: web.Request) -> web.Response:
+        return web.Response(text='{"other_key": 1}')
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/new_search", no_elastic)
+    websession = await aiohttp_client(app)
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="user",
+        password="pass",
+    )
+    client = Client(websession=websession, account=account)
+    await client.authenticate()
+
+    readers = await account.fetch_meter_readers_new_search(client)
+    assert readers == []  # nosec: B101
+
+
+@pytest.mark.asyncio()
+async def test_new_search_meter_uuid_from_source_direct(aiohttp_client: Any) -> None:
+    """meter_uuid found directly in _source (not nested under 'meter') is used."""
+
+    async def direct_source(_request: web.Request) -> web.Response:
+        data = (
+            '{"elastic_results": {"hits": {"hits": ['
+            '{"_source": {"meter_uuid": "src_uuid", "meter_id": "src_id"}}'
+            ']}}}'
+        )
+        return web.Response(text=data)
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/new_search", direct_source)
+    websession = await aiohttp_client(app)
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="user",
+        password="pass",
+    )
+    client = Client(websession=websession, account=account)
+    await client.authenticate()
+
+    readers = await account.fetch_meter_readers_new_search(client)
+    assert len(readers) == 1  # nosec: B101
+    assert readers[0].meter_uuid == "src_uuid"  # nosec: B101
+    assert readers[0].meter_id == "src_id"  # nosec: B101
 
 
 @pytest.mark.asyncio()
@@ -377,7 +463,7 @@ async def test_client_new_search_ignores_id_as_uuid(aiohttp_client: Any) -> None
         data = (
             '{"elastic_results": {"hits": {"hits": ['
             '{"_id": "es_doc_id", "_source": {"meter_id": "456"}}'
-            "]}}}"
+            ']}}}'
         )
         return web.Response(text=data)
 
@@ -386,9 +472,142 @@ async def test_client_new_search_ignores_id_as_uuid(aiohttp_client: Any) -> None
     app.router.add_post("/api/2/residential/new_search", mock_new_search_id_only)
     websession = await aiohttp_client(app)
 
-    account = Account(eow_hostname="", username="user", password="")  # nosec: B106
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="user",
+        password="",
+    )
     client = Client(websession=websession, account=account)
     await client.authenticate()
 
     readers = await account.fetch_meter_readers_new_search(client=client)
-    assert len(readers) == 0  # nosec: B101
+    assert readers == []  # nosec: B101
+
+
+@pytest.mark.asyncio()
+async def test_new_search_skips_hit_with_no_uuid_or_id(aiohttp_client: Any) -> None:
+    """Hit with no discoverable meter_uuid or meter_id is skipped → returns []."""
+
+    async def no_ids(_request: web.Request) -> web.Response:
+        data = (
+            '{"elastic_results": {"hits": {"hits": ['
+            '{"_source": {}}'
+            ']}}}'
+        )
+        return web.Response(text=data)
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/new_search", no_ids)
+    websession = await aiohttp_client(app)
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="user",
+        password="pass",
+    )
+    client = Client(websession=websession, account=account)
+    await client.authenticate()
+
+    readers = await account.fetch_meter_readers_new_search(client)
+    assert readers == []  # nosec: B101
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — sync unit tests (no aiohttp server)
+# ---------------------------------------------------------------------------
+
+
+def test_is_token_valid_not_authenticated() -> None:
+    """Not authenticated and token expired → is_token_valid is False."""
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="u",
+        password="p",
+    )
+    client = Client(websession=MagicMock(), account=account)
+    client.authenticated = False
+    client.token_expiration = datetime.datetime.now() - datetime.timedelta(seconds=1)
+    assert client.is_token_valid is False  # nosec: B101
+
+
+def test_is_token_valid_authenticated_not_expired() -> None:
+    """Authenticated with future token expiration → is_token_valid is True."""
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="u",
+        password="p",
+    )
+    client = Client(websession=MagicMock(), account=account)
+    client.authenticated = True
+    client.token_expiration = datetime.datetime.now() + datetime.timedelta(hours=1)
+    assert client.is_token_valid is True  # nosec: B101
+
+
+def test_is_token_valid_authenticated_expired() -> None:
+    """Authenticated but expired token should be treated as invalid."""
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="u",
+        password="p",
+    )
+    client = Client(websession=MagicMock(), account=account)
+    client.authenticated = True
+    client.token_expiration = datetime.datetime.now() - datetime.timedelta(seconds=1)
+    assert client.is_token_valid is False  # nosec: B101
+
+
+def test_extract_json_matching_prefix() -> None:
+    """extract_json strips prefix and trailing semicolon, then parses JSON."""
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="u",
+        password="p",
+    )
+    client = Client(websession=MagicMock(), account=account)
+    line = 'prefix[{"key": "val"}];'
+    result = client.extract_json(line, "prefix")
+    assert result == [{"key": "val"}]  # nosec: B101
+
+
+def test_extract_json_no_match() -> None:
+    """extract_json with no matching prefix produces an invalid slice → JSONDecodeError.
+
+    NOTE: In production, callers guard with `if prefix in line` before calling.
+    This test documents the unguarded behavior.
+    """
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="u",
+        password="p",
+    )
+    client = Client(websession=MagicMock(), account=account)
+    with pytest.raises(json.JSONDecodeError):
+        client.extract_json("no prefix here; text", "MISSING_PREFIX = ")
+
+
+def test_truncate_payload_short_unchanged() -> None:
+    """Payloads at or under 1000 chars are returned unmodified."""
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="u",
+        password="p",
+    )
+    client = Client(websession=MagicMock(), account=account)
+    payload_999 = "X" * 999
+    payload_1000 = "X" * 1000
+    assert client._truncate_payload(payload_999) == payload_999  # nosec: B101
+    assert client._truncate_payload(payload_1000) == payload_1000  # nosec: B101
+
+
+def test_truncate_payload_long_truncated() -> None:
+    """Payloads over 1000 chars are truncated to 1000 chars plus '...'."""
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="u",
+        password="p",
+    )
+    client = Client(websession=MagicMock(), account=account)
+    payload = "X" * 1001
+    result = client._truncate_payload(payload)
+    assert result == "X" * 1000 + "..."  # nosec: B101
+    assert len(result) == 1003  # nosec: B101

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -435,7 +435,7 @@ async def test_new_search_meter_uuid_from_source_direct(aiohttp_client: Any) -> 
         data = (
             '{"elastic_results": {"hits": {"hits": ['
             '{"_source": {"meter_uuid": "src_uuid", "meter_id": "src_id"}}'
-            ']}}}'
+            "]}}}"
         )
         return web.Response(text=data)
 
@@ -465,7 +465,7 @@ async def test_client_new_search_ignores_id_as_uuid(aiohttp_client: Any) -> None
         data = (
             '{"elastic_results": {"hits": {"hits": ['
             '{"_id": "es_doc_id", "_source": {"meter_id": "456"}}'
-            ']}}}'
+            "]}}}"
         )
         return web.Response(text=data)
 
@@ -529,7 +529,7 @@ def test_is_token_valid_not_authenticated() -> None:
 
 
 def test_is_token_valid_not_authenticated_not_expired() -> None:
-    """Future token expiration keeps the token valid even when not authenticated."""
+    """Unauthenticated clients are invalid even if the expiration time is in the future."""
     account = Account(  # nosec: B106
         eow_hostname="",
         username="u",
@@ -538,7 +538,7 @@ def test_is_token_valid_not_authenticated_not_expired() -> None:
     client = Client(websession=MagicMock(), account=account)
     client.authenticated = False
     client.token_expiration = datetime.datetime.now() + datetime.timedelta(hours=1)
-    assert client.is_token_valid is True  # nosec: B101
+    assert client.is_token_valid is False  # nosec: B101
 
 
 def test_is_token_valid_authenticated_expired() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,8 +2,9 @@
 
 import datetime
 import json
+import logging
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from aiohttp import web
 from conftest import (
@@ -17,6 +18,7 @@ import pytest
 from pyonwater import (
     Account,
     Client,
+    EyeOnWaterAPIError,
     EyeOnWaterAuthError,
     EyeOnWaterException,
     EyeOnWaterRateLimitError,
@@ -489,11 +491,7 @@ async def test_new_search_skips_hit_with_no_uuid_or_id(aiohttp_client: Any) -> N
     """Hit with no discoverable meter_uuid or meter_id is skipped → returns []."""
 
     async def no_ids(_request: web.Request) -> web.Response:
-        data = (
-            '{"elastic_results": {"hits": {"hits": ['
-            '{"_source": {}}'
-            ']}}}'
-        )
+        data = json.dumps({"elastic_results": {"hits": {"hits": [{"_source": {}}]}}})
         return web.Response(text=data)
 
     app = web.Application()
@@ -530,15 +528,15 @@ def test_is_token_valid_not_authenticated() -> None:
     assert client.is_token_valid is False  # nosec: B101
 
 
-def test_is_token_valid_authenticated_not_expired() -> None:
-    """Authenticated with future token expiration → is_token_valid is True."""
+def test_is_token_valid_not_authenticated_not_expired() -> None:
+    """Future token expiration keeps the token valid even when not authenticated."""
     account = Account(  # nosec: B106
         eow_hostname="",
         username="u",
         password="p",
     )
     client = Client(websession=MagicMock(), account=account)
-    client.authenticated = True
+    client.authenticated = False
     client.token_expiration = datetime.datetime.now() + datetime.timedelta(hours=1)
     assert client.is_token_valid is True  # nosec: B101
 
@@ -585,29 +583,62 @@ def test_extract_json_no_match() -> None:
         client.extract_json("no prefix here; text", "MISSING_PREFIX = ")
 
 
-def test_truncate_payload_short_unchanged() -> None:
-    """Payloads at or under 1000 chars are returned unmodified."""
-    account = Account(  # nosec: B106
-        eow_hostname="",
-        username="u",
-        password="p",
-    )
-    client = Client(websession=MagicMock(), account=account)
+@pytest.mark.asyncio()
+async def test_request_logs_short_error_payload_unchanged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Short error payloads are logged unchanged through the public request API."""
     payload_999 = "X" * 999
     payload_1000 = "X" * 1000
-    assert client._truncate_payload(payload_999) == payload_999  # nosec: B101
-    assert client._truncate_payload(payload_1000) == payload_1000  # nosec: B101
+    response = MagicMock(status=503)
+    response.text = AsyncMock(side_effect=[payload_999, payload_1000])
+    websession = MagicMock()
+    websession.request = AsyncMock(return_value=response)
 
-
-def test_truncate_payload_long_truncated() -> None:
-    """Payloads over 1000 chars are truncated to 1000 chars plus '...'."""
     account = Account(  # nosec: B106
         eow_hostname="",
         username="u",
         password="p",
     )
-    client = Client(websession=MagicMock(), account=account)
+    client = Client(websession=websession, account=account)
+    client.authenticated = True
+    client.token_expiration = datetime.datetime.now() + datetime.timedelta(hours=1)
+
+    with caplog.at_level(logging.ERROR, logger="pyonwater.client"):
+        with pytest.raises(EyeOnWaterAPIError, match="Request failed: 503"):
+            await client.request("/dashboard/user", "get")
+        with pytest.raises(EyeOnWaterAPIError, match="Request failed: 503"):
+            await client.request("/dashboard/user", "get")
+
+    assert payload_999 in caplog.text  # nosec: B101
+    assert payload_1000 in caplog.text  # nosec: B101
+    assert f"{payload_1000}..." not in caplog.text  # nosec: B101
+
+
+@pytest.mark.asyncio()
+async def test_request_logs_long_error_payload_truncated(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Long error payloads are truncated in logs through the public request API."""
     payload = "X" * 1001
-    result = client._truncate_payload(payload)
-    assert result == "X" * 1000 + "..."  # nosec: B101
-    assert len(result) == 1003  # nosec: B101
+    response = MagicMock(status=503)
+    response.text = AsyncMock(return_value=payload)
+    websession = MagicMock()
+    websession.request = AsyncMock(return_value=response)
+
+    account = Account(  # nosec: B106
+        eow_hostname="",
+        username="u",
+        password="p",
+    )
+    client = Client(websession=websession, account=account)
+    client.authenticated = True
+    client.token_expiration = datetime.datetime.now() + datetime.timedelta(hours=1)
+
+    with caplog.at_level(logging.ERROR, logger="pyonwater.client"):
+        with pytest.raises(EyeOnWaterAPIError, match="Request failed: 503"):
+            await client.request("/dashboard/user", "get")
+
+    expected = "X" * 1000 + "..."
+    assert expected in caplog.text  # nosec: B101
+    assert payload not in caplog.text  # nosec: B101

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from aiohttp import web
 from conftest import (
@@ -21,6 +21,7 @@ from pyonwater import (
     EOWUnits,
     EyeOnWaterException,
     EyeOnWaterUnitError,
+    MeterReader,
     NativeUnits,
 )
 
@@ -361,3 +362,115 @@ async def test_meter_convert_to_native_preserves_flow_and_end_dt(
     assert converted.reading == 100.0
     assert converted.flow_value == 200.0
     assert converted.end_dt == end_dt
+
+
+async def test_meter_cache_keeps_newer_data(aiohttp_client: Any) -> None:
+    """Cache is not overwritten when incoming data has an older timestamp."""
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/new_search", mock_read_meter_endpoint)
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    meter = await build_meter(client)
+
+    newer_point = DataPoint(
+        dt=datetime(2026, 3, 2, tzinfo=timezone.utc),
+        reading=200.0,
+        unit=EOWUnits.UNIT_GAL,
+    )
+    older_point = DataPoint(
+        dt=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        reading=100.0,
+        unit=EOWUnits.UNIT_GAL,
+    )
+
+    with patch.object(
+        MeterReader,
+        "read_historical_data",
+        new=AsyncMock(side_effect=[[newer_point], [older_point]]),
+    ):
+        await meter.read_historical_data(client=client, days_to_load=1)
+        first_dt = meter.last_historical_data[0].dt
+        first_reading = meter.last_historical_data[0].reading
+
+        # Second read returns older data — cache must NOT be overwritten
+        await meter.read_historical_data(client=client, days_to_load=1)
+
+    assert meter.last_historical_data[0].dt == first_dt
+    assert meter.last_historical_data[0].reading == first_reading
+
+
+async def test_meter_cache_not_updated_for_same_timestamp(aiohttp_client: Any) -> None:
+    """Cache is not overwritten when same-timestamp data with equal count arrives."""
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/new_search", mock_read_meter_endpoint)
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    meter = await build_meter(client)
+
+    point = DataPoint(
+        dt=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        reading=100.0,
+        unit=EOWUnits.UNIT_GAL,
+    )
+
+    with patch.object(
+        MeterReader,
+        "read_historical_data",
+        new=AsyncMock(side_effect=[[point], [point]]),
+    ):
+        await meter.read_historical_data(client=client, days_to_load=1)
+        assert len(meter.last_historical_data) == 1
+        first_list_id = id(meter.last_historical_data)
+
+        # Second read: same timestamp, same count — list must NOT be reassigned
+        await meter.read_historical_data(client=client, days_to_load=1)
+
+    # id() identity check: self.last_historical_data = historical_data was NOT executed
+    assert id(meter.last_historical_data) == first_list_id
+
+
+async def test_meter_read_include_today_false(aiohttp_client: Any) -> None:
+    """include_today=False: end_date is yesterday, start_date is (days_to_load-1) days earlier."""
+    captured_params: dict[str, str] = {}
+
+    async def mock_initiate(request: web.Request) -> web.Response:
+        captured_params.update(dict(request.query))
+        return web.Response(text='{"task_id":"task-x"}')
+
+    async def mock_status(_request: web.Request) -> web.Response:
+        return web.Response(
+            text='{"state":"done","result":{"url":"/export/dl.csv"}}'
+        )
+
+    async def mock_csv(_request: web.Request) -> web.Response:
+        return web.Response(text="Read_Time,Read,Read_Unit,Flow,Timezone\n")
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_get("/reports/export_initiate", mock_initiate)
+    app.router.add_get("/reports/export_check_status/task-x", mock_status)
+    app.router.add_get("/export/dl.csv", mock_csv)
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    # Fix "today" to 2026-03-10 so date assertions are deterministic.
+    # Patching datetime.datetime only; datetime.timedelta remains the real class.
+    fixed_now = datetime(2026, 3, 10, 12, 0, 0, tzinfo=timezone.utc)
+    with patch("pyonwater.meter_reader.datetime.datetime") as mock_dt:
+        mock_dt.now.return_value = fixed_now
+        with patch("pyonwater.meter_reader.asyncio.sleep"):
+            await reader.read_historical_data_range_export(
+                client=client,
+                days_to_load=3,
+                include_today=False,
+                poll_interval=0.0,
+            )
+
+    # include_today=False, today=2026-03-10:
+    #   end_date   = 2026-03-09  (today - 1)
+    #   start_date = 2026-03-07  (end_date - (3-1) days)
+    assert captured_params["end-date"] == "03/09/2026"
+    assert captured_params["start-date"] == "03/07/2026"

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -440,9 +440,7 @@ async def test_meter_read_include_today_false(aiohttp_client: Any) -> None:
         return web.Response(text='{"task_id":"task-x"}')
 
     async def mock_status(_request: web.Request) -> web.Response:
-        return web.Response(
-            text='{"state":"done","result":{"url":"/export/dl.csv"}}'
-        )
+        return web.Response(text='{"state":"done","result":{"url":"/export/dl.csv"}}')
 
     async def mock_csv(_request: web.Request) -> web.Response:
         return web.Response(text="Read_Time,Read,Read_Unit,Flow,Timezone\n")

--- a/tests/test_meter_reader.py
+++ b/tests/test_meter_reader.py
@@ -252,13 +252,13 @@ async def test_meter_reader_range_export(aiohttp_client: Any) -> None:
 def test_normalize_export_path() -> None:
     """Verify export URLs are converted into client request paths."""
     assert (  # nosec: B101
-        MeterReader._normalize_export_path(
+        MeterReader.normalize_export_path(
             "https://eyeonwater.com/export/download.csv?token=abc"
         )
         == "/export/download.csv?token=abc"
     )
     assert (
-        MeterReader._normalize_export_path("/export/download.csv")
+        MeterReader.normalize_export_path("/export/download.csv")
         == "/export/download.csv"
     )  # nosec: B101
 
@@ -266,7 +266,7 @@ def test_normalize_export_path() -> None:
 def test_parse_export_datetime_invalid() -> None:
     """Verify invalid export timestamps raise a clear error."""
     with pytest.raises(ValueError, match="Unrecognized export datetime"):
-        MeterReader._parse_export_datetime("not-a-date")
+        MeterReader.parse_export_datetime("not-a-date")
 
 
 def test_parse_export_csv_skips_invalid_rows_with_warning(
@@ -281,7 +281,7 @@ def test_parse_export_csv_skips_invalid_rows_with_warning(
     )
 
     with caplog.at_level(logging.WARNING, logger="pyonwater.meter_reader"):
-        points = reader._parse_export_csv(raw_csv)
+        points = reader.parse_export_csv(raw_csv)
 
     assert len(points) == 1  # nosec: B101
     assert points[0].reading == 100.0  # nosec: B101

--- a/tests/test_meter_reader.py
+++ b/tests/test_meter_reader.py
@@ -326,9 +326,7 @@ async def test_export_range_invalid_poll_interval() -> None:
 
     reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
     client_mock = AsyncMock()
-    with pytest.raises(
-        ValueError, match="poll_interval must be non-negative, got -1"
-    ):
+    with pytest.raises(ValueError, match="poll_interval must be non-negative, got -1"):
         await reader.read_historical_data_range_export(
             client_mock, days_to_load=1, max_retries=1, poll_interval=-1
         )
@@ -382,9 +380,7 @@ async def test_export_range_missing_url(aiohttp_client: Any) -> None:
         return web.Response(text='{"task_id": "task-abc"}')
 
     async def mock_status(_request: web.Request) -> web.Response:
-        return web.Response(
-            text='{"state": "done", "result": {"no_url_here": 1}}'
-        )
+        return web.Response(text='{"state": "done", "result": {"no_url_here": 1}}')
 
     app.router.add_get("/reports/export_initiate", mock_initiate)
     app.router.add_get("/reports/export_check_status/task-abc", mock_status)
@@ -472,7 +468,9 @@ def test_parse_export_csv_space_column_names() -> None:
     "Read_Time" and "Read_Unit". Both must be recognised.
     """
     reader = MeterReader(meter_uuid="x", meter_id="x")
-    raw_csv = "Read Time,Read,Unit,Flow,Timezone\n03/01/2026 12:15,100.0,GAL,,US/Pacific\n"
+    raw_csv = (
+        "Read Time,Read,Unit,Flow,Timezone\n03/01/2026 12:15,100.0,GAL,,US/Pacific\n"
+    )
 
     points = reader.parse_export_csv(raw_csv)
 
@@ -494,7 +492,9 @@ def test_parse_export_csv_empty_string() -> None:
 def test_parse_export_csv_no_flow_column() -> None:
     """parse_export_csv sets flow_value to None when the Flow column is absent."""
     reader = MeterReader(meter_uuid="x", meter_id="x")
-    raw_csv = "Read_Time,Read,Read_Unit,Timezone\n03/01/2026 12:15,100.0,GAL,US/Pacific\n"
+    raw_csv = (
+        "Read_Time,Read,Read_Unit,Timezone\n03/01/2026 12:15,100.0,GAL,US/Pacific\n"
+    )
 
     points = reader.parse_export_csv(raw_csv)
 

--- a/tests/test_meter_reader.py
+++ b/tests/test_meter_reader.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import logging
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from aiohttp import web
 from conftest import (
@@ -298,8 +298,6 @@ def test_parse_export_csv_skips_invalid_rows_with_warning(
 @pytest.mark.asyncio()
 async def test_export_range_invalid_days_to_load() -> None:
     """ValueError raised when days_to_load=0."""
-    from unittest.mock import AsyncMock
-
     reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
     client_mock = AsyncMock()
     with pytest.raises(ValueError, match="days_to_load must be at least 1, got 0"):
@@ -309,8 +307,6 @@ async def test_export_range_invalid_days_to_load() -> None:
 @pytest.mark.asyncio()
 async def test_export_range_invalid_max_retries() -> None:
     """ValueError raised when max_retries=0."""
-    from unittest.mock import AsyncMock
-
     reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
     client_mock = AsyncMock()
     with pytest.raises(ValueError, match="max_retries must be at least 1, got 0"):
@@ -322,8 +318,6 @@ async def test_export_range_invalid_max_retries() -> None:
 @pytest.mark.asyncio()
 async def test_export_range_invalid_poll_interval() -> None:
     """ValueError raised when poll_interval is negative."""
-    from unittest.mock import AsyncMock
-
     reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
     client_mock = AsyncMock()
     with pytest.raises(ValueError, match="poll_interval must be non-negative, got -1"):
@@ -486,7 +480,7 @@ def test_parse_export_csv_empty_string() -> None:
 
     points = reader.parse_export_csv("")
 
-    assert points == []  # nosec: B101
+    assert not points  # nosec: B101
 
 
 def test_parse_export_csv_no_flow_column() -> None:

--- a/tests/test_meter_reader.py
+++ b/tests/test_meter_reader.py
@@ -1,5 +1,6 @@
 """Tests for pyonwater meter reader."""  # nosec: B101, B106
 
+import datetime
 import json
 import logging
 from typing import Any
@@ -16,7 +17,8 @@ from conftest import (
 )
 import pytest
 
-from pyonwater import EyeOnWaterAPIError, MeterReader
+from pyonwater import EyeOnWaterAPIError, EyeOnWaterResponseIsEmpty, MeterReader
+from pyonwater.models.units import AggregationLevel, RequestUnits
 
 
 @pytest.mark.asyncio()
@@ -286,3 +288,379 @@ def test_parse_export_csv_skips_invalid_rows_with_warning(
     assert len(points) == 1  # nosec: B101
     assert points[0].reading == 100.0  # nosec: B101
     assert "Skipping unparsable CSV row" in caplog.text  # nosec: B101
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Export validation, poll error/timeout, normalize_export_path edge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_export_range_invalid_days_to_load() -> None:
+    """ValueError raised when days_to_load=0."""
+    from unittest.mock import AsyncMock
+
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+    client_mock = AsyncMock()
+    with pytest.raises(ValueError, match="days_to_load must be at least 1, got 0"):
+        await reader.read_historical_data_range_export(client_mock, days_to_load=0)
+
+
+@pytest.mark.asyncio()
+async def test_export_range_invalid_max_retries() -> None:
+    """ValueError raised when max_retries=0."""
+    from unittest.mock import AsyncMock
+
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+    client_mock = AsyncMock()
+    with pytest.raises(ValueError, match="max_retries must be at least 1, got 0"):
+        await reader.read_historical_data_range_export(
+            client_mock, days_to_load=1, max_retries=0
+        )
+
+
+@pytest.mark.asyncio()
+async def test_export_range_invalid_poll_interval() -> None:
+    """ValueError raised when poll_interval is negative."""
+    from unittest.mock import AsyncMock
+
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+    client_mock = AsyncMock()
+    with pytest.raises(
+        ValueError, match="poll_interval must be non-negative, got -1"
+    ):
+        await reader.read_historical_data_range_export(
+            client_mock, days_to_load=1, max_retries=1, poll_interval=-1
+        )
+
+
+@pytest.mark.asyncio()
+async def test_export_range_bad_initiate_json(aiohttp_client: Any) -> None:
+    """EyeOnWaterAPIError raised when initiate endpoint returns non-JSON."""
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+
+    async def mock_bad_json(_request: web.Request) -> web.Response:
+        return web.Response(text="not json")
+
+    app.router.add_get("/reports/export_initiate", mock_bad_json)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    with pytest.raises(EyeOnWaterAPIError):
+        await reader.read_historical_data_range_export(client, days_to_load=1)
+
+
+@pytest.mark.asyncio()
+async def test_export_range_missing_task_id(aiohttp_client: Any) -> None:
+    """EyeOnWaterAPIError raised when initiate response has no task_id."""
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+
+    async def mock_no_task_id(_request: web.Request) -> web.Response:
+        return web.Response(text='{"status": "ok"}')
+
+    app.router.add_get("/reports/export_initiate", mock_no_task_id)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    with pytest.raises(EyeOnWaterAPIError, match="Export task id not found"):
+        await reader.read_historical_data_range_export(client, days_to_load=1)
+
+
+@pytest.mark.asyncio()
+async def test_export_range_missing_url(aiohttp_client: Any) -> None:
+    """EyeOnWaterAPIError raised when poll result has no url key."""
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+
+    async def mock_initiate(_request: web.Request) -> web.Response:
+        return web.Response(text='{"task_id": "task-abc"}')
+
+    async def mock_status(_request: web.Request) -> web.Response:
+        return web.Response(
+            text='{"state": "done", "result": {"no_url_here": 1}}'
+        )
+
+    app.router.add_get("/reports/export_initiate", mock_initiate)
+    app.router.add_get("/reports/export_check_status/task-abc", mock_status)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    with patch("pyonwater.meter_reader.asyncio.sleep"):
+        with pytest.raises(EyeOnWaterAPIError, match="Export result missing URL"):
+            await reader.read_historical_data_range_export(
+                client, days_to_load=1, poll_interval=0.0
+            )
+
+
+@pytest.mark.asyncio()
+async def test_poll_export_task_error_state(aiohttp_client: Any) -> None:
+    """EyeOnWaterAPIError raised when poll returns error state with message."""
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+
+    async def mock_initiate(_request: web.Request) -> web.Response:
+        return web.Response(text='{"task_id": "task-err"}')
+
+    async def mock_status(_request: web.Request) -> web.Response:
+        return web.Response(
+            text='{"state": "error", "message": "Something went wrong"}'
+        )
+
+    app.router.add_get("/reports/export_initiate", mock_initiate)
+    app.router.add_get("/reports/export_check_status/task-err", mock_status)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    with patch("pyonwater.meter_reader.asyncio.sleep"):
+        with pytest.raises(EyeOnWaterAPIError, match="Something went wrong"):
+            await reader.read_historical_data_range_export(
+                client, days_to_load=1, poll_interval=0.0
+            )
+
+
+@pytest.mark.asyncio()
+async def test_poll_export_task_timeout(aiohttp_client: Any) -> None:
+    """EyeOnWaterAPIError raised when poll exhausts max_retries."""
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+
+    async def mock_initiate(_request: web.Request) -> web.Response:
+        return web.Response(text='{"task_id": "task-timeout"}')
+
+    async def mock_status(_request: web.Request) -> web.Response:
+        return web.Response(text='{"state": "pending"}')
+
+    app.router.add_get("/reports/export_initiate", mock_initiate)
+    app.router.add_get("/reports/export_check_status/task-timeout", mock_status)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    with patch("pyonwater.meter_reader.asyncio.sleep"):
+        with pytest.raises(EyeOnWaterAPIError, match="did not complete"):
+            await reader.read_historical_data_range_export(
+                client, days_to_load=1, max_retries=2, poll_interval=0.0
+            )
+
+
+def test_normalize_export_path_invalid() -> None:
+    """EyeOnWaterAPIError raised for unsupported URL schemes."""
+    with pytest.raises(EyeOnWaterAPIError, match="Unsupported export url format"):
+        MeterReader.normalize_export_path("ftp://weird.com/file")
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: parse_export_csv column variants + one_day empty response forms
+# ---------------------------------------------------------------------------
+
+
+def test_parse_export_csv_space_column_names() -> None:
+    """parse_export_csv handles space-separated column name variants.
+
+    The real API sometimes uses "Read Time" and "Unit" instead of
+    "Read_Time" and "Read_Unit". Both must be recognised.
+    """
+    reader = MeterReader(meter_uuid="x", meter_id="x")
+    raw_csv = "Read Time,Read,Unit,Flow,Timezone\n03/01/2026 12:15,100.0,GAL,,US/Pacific\n"
+
+    points = reader.parse_export_csv(raw_csv)
+
+    assert len(points) == 1  # nosec: B101
+    assert points[0].reading == 100.0  # nosec: B101
+    assert points[0].unit == "GAL"  # nosec: B101
+    assert points[0].flow_value is None  # nosec: B101
+
+
+def test_parse_export_csv_empty_string() -> None:
+    """parse_export_csv returns an empty list for an empty string input."""
+    reader = MeterReader(meter_uuid="x", meter_id="x")
+
+    points = reader.parse_export_csv("")
+
+    assert points == []  # nosec: B101
+
+
+def test_parse_export_csv_no_flow_column() -> None:
+    """parse_export_csv sets flow_value to None when the Flow column is absent."""
+    reader = MeterReader(meter_uuid="x", meter_id="x")
+    raw_csv = "Read_Time,Read,Read_Unit,Timezone\n03/01/2026 12:15,100.0,GAL,US/Pacific\n"
+
+    points = reader.parse_export_csv(raw_csv)
+
+    assert len(points) == 1  # nosec: B101
+    assert points[0].reading == 100.0  # nosec: B101
+    assert points[0].flow_value is None  # nosec: B101
+
+
+@pytest.mark.asyncio()
+async def test_read_historical_data_one_day_quoted_empty(
+    aiohttp_client: Any,
+) -> None:
+    """EyeOnWaterResponseIsEmpty raised when consumption returns '""'.
+
+    The real API returns the JSON-encoded empty string '""' to signal no data.
+    """
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+
+    async def mock_quoted_empty(_request: web.Request) -> web.Response:
+        return web.Response(text='""')
+
+    app.router.add_post("/api/2/residential/consumption", mock_quoted_empty)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    with pytest.raises(EyeOnWaterResponseIsEmpty):
+        await reader.read_historical_data_one_day(
+            client=client,
+            date=datetime.datetime(2026, 3, 1),
+        )
+
+
+@pytest.mark.asyncio()
+async def test_read_historical_data_one_day_null_response(
+    aiohttp_client: Any,
+) -> None:
+    """EyeOnWaterResponseIsEmpty raised when consumption returns 'null'.
+
+    The real API returns the string 'null' to signal no data.
+    """
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+
+    async def mock_null(_request: web.Request) -> web.Response:
+        return web.Response(text="null")
+
+    app.router.add_post("/api/2/residential/consumption", mock_null)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    with pytest.raises(EyeOnWaterResponseIsEmpty):
+        await reader.read_historical_data_one_day(
+            client=client,
+            date=datetime.datetime(2026, 3, 1),
+        )
+
+
+@pytest.mark.asyncio()
+async def test_read_historical_data_one_day_missing_timeseries_key(
+    aiohttp_client: Any,
+) -> None:
+    """EyeOnWaterResponseIsEmpty raised when the meter_uuid key is absent.
+
+    The historical data fixture uses key "meter_uuid,0". When the MeterReader
+    has uuid "test_meter" it looks for "test_meter,0", which is not present,
+    triggering the missing-key path.
+    """
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+
+    async def mock_wrong_key(_request: web.Request) -> web.Response:
+        with open(
+            "tests/mock_data/historical_data_mock_anonymized.json", encoding="utf-8"
+        ) as f:
+            return web.Response(text=f.read())
+
+    app.router.add_post("/api/2/residential/consumption", mock_wrong_key)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    # Reader uuid "test_meter" → looks for "test_meter,0"; fixture has "meter_uuid,0"
+    reader = MeterReader(meter_uuid="test_meter", meter_id="test_id")
+
+    with pytest.raises(EyeOnWaterResponseIsEmpty):
+        await reader.read_historical_data_one_day(
+            client=client,
+            date=datetime.datetime(2026, 3, 1),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: AggregationLevel parametrize + RequestUnits forwarding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("level", list(AggregationLevel))
+@pytest.mark.asyncio()
+async def test_read_historical_data_one_day_all_aggregation_levels(
+    aiohttp_client: Any, level: AggregationLevel
+) -> None:
+    """All AggregationLevel values produce a successful consumption request.
+
+    For each enum member the aggregate field in the POST body must match the
+    enum's wire value and the endpoint must return valid data.
+    """
+    captured_body: dict[str, Any] = {}
+
+    async def mock_consumption(request: web.Request) -> web.Response:
+        captured_body.update(await request.json())
+        with open(
+            "tests/mock_data/historical_data_mock_anonymized.json", encoding="utf-8"
+        ) as f:
+            return web.Response(text=f.read())
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/consumption", mock_consumption)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    await reader.read_historical_data_one_day(
+        client=client,
+        date=datetime.datetime(2026, 3, 1),
+        aggregation=level,
+    )
+
+    assert captured_body["params"]["aggregate"] == level.value  # nosec: B101
+
+
+@pytest.mark.asyncio()
+async def test_read_historical_data_one_day_units_forwarded(
+    aiohttp_client: Any,
+) -> None:
+    """The units parameter is forwarded verbatim in the POST body.
+
+    Verifies that passing RequestUnits.GALLONS results in the string "gallons"
+    appearing in the params.units field of the consumption request.
+    """
+    captured_body: dict[str, Any] = {}
+
+    async def mock_consumption(request: web.Request) -> web.Response:
+        captured_body.update(await request.json())
+        with open(
+            "tests/mock_data/historical_data_mock_anonymized.json", encoding="utf-8"
+        ) as f:
+            return web.Response(text=f.read())
+
+    app = web.Application()
+    app.router.add_post("/account/signin", mock_signin_endpoint)
+    app.router.add_post("/api/2/residential/consumption", mock_consumption)
+
+    websession = await aiohttp_client(app)
+    _, client = await build_client(websession)
+    reader = MeterReader(meter_uuid="meter_uuid", meter_id="meter_id")
+
+    await reader.read_historical_data_one_day(
+        client=client,
+        date=datetime.datetime(2026, 3, 1),
+        units=RequestUnits.GALLONS,
+    )
+
+    assert captured_body["params"]["units"] == RequestUnits.GALLONS.value  # nosec: B101

--- a/tests/test_models_extensions.py
+++ b/tests/test_models_extensions.py
@@ -1,8 +1,42 @@
 """Tests for additional model fields."""
 
+import json
+from pathlib import Path
 from typing import Any
 
+import pytest
+from pydantic import ValidationError
+
 from pyonwater.models import MeterInfo
+from pyonwater.models.eow_historical_models import HistoricalData, Hit, Params, TimeSerie
+from pyonwater.models.eow_models import Battery, Flags, LatestRead, Pwr
+from pyonwater.models.units import EOWUnits
+
+# ---------------------------------------------------------------------------
+# Module-level constants shared across Phase 6 tests
+# ---------------------------------------------------------------------------
+_MINIMAL_FLAGS: dict[str, bool] = {
+    "EmptyPipe": False,
+    "Leak": False,
+    "CoverRemoved": False,
+    "Tamper": False,
+    "ReverseFlow": False,
+    "LowBattery": False,
+    "BatteryCharging": False,
+}
+_MINIMAL_LATEST_READ: dict[str, object] = {
+    "full_read": 0.0,
+    "units": "GAL",
+    "read_time": "2026-01-01T00:00:00Z",
+}
+_MINIMAL_REGISTER_0: dict[str, object] = {
+    "flags": _MINIMAL_FLAGS,
+    "latest_read": _MINIMAL_LATEST_READ,
+}
+_MINIMAL_HIT: dict[str, object] = {"meter.timezone": ["America/New_York"]}
+_MINIMAL_TIMESERIES: dict[str, object] = {
+    "grp1": {"series": [{"date": "2026-01-01", "value": 5.0}]}
+}
 
 
 def test_meter_info_parses_leak_fields() -> None:
@@ -44,3 +78,120 @@ def test_meter_info_parses_leak_fields() -> None:
     assert model.meter.leak.max_flow_rate == 0.9
     assert model.reading.leak is not None
     assert model.reading.leak.total_leak_24hrs == 5.6
+
+
+# ---------------------------------------------------------------------------
+# Group A — ValidationError paths
+# ---------------------------------------------------------------------------
+
+
+def test_flags_missing_mandatory_field_raises() -> None:
+    """Flags without EmptyPipe (mandatory aliased field) raises ValidationError."""
+    with pytest.raises(ValidationError):
+        Flags.model_validate(
+            {
+                # EmptyPipe intentionally omitted
+                "Leak": False,
+                "CoverRemoved": False,
+                "Tamper": False,
+                "ReverseFlow": False,
+                "LowBattery": False,
+                "BatteryCharging": False,
+            }
+        )
+
+
+def test_latest_read_invalid_units_raises() -> None:
+    """LatestRead with unrecognized units string raises ValidationError."""
+    with pytest.raises(ValidationError):
+        LatestRead.model_validate(
+            {
+                "full_read": 1.0,
+                "units": "MEGAGALLON",
+                "read_time": "2026-01-01T00:00:00Z",
+            }
+        )
+
+
+def test_meter_info_missing_register_0_raises() -> None:
+    """MeterInfo without required register_0 raises ValidationError."""
+    with pytest.raises(ValidationError):
+        MeterInfo.model_validate({})
+
+
+def test_hit_missing_timezone_raises() -> None:
+    """Hit without mandatory meter.timezone field raises ValidationError."""
+    with pytest.raises(ValidationError):
+        Hit.model_validate({})
+
+
+# ---------------------------------------------------------------------------
+# Group B — Valid minimal construction with aliased fields
+# ---------------------------------------------------------------------------
+
+
+def test_battery_register_alias_maps_to_attribute() -> None:
+    """Battery 'register' JSON key maps to register_ Python attribute."""
+    b = Battery.model_validate({"register": 5, "level": 80})
+    assert b.register_ == 5
+    assert b.level == 80
+
+
+def test_pwr_register_alias_maps_to_attribute() -> None:
+    """Pwr 'register' JSON key maps to register_ Python attribute."""
+    p = Pwr.model_validate({"register": 3, "signal_strength": 90})
+    assert p.register_ == 3
+
+
+def test_timeserie_empty_series_is_valid() -> None:
+    """TimeSerie with an empty series list is a valid API response."""
+    ts = TimeSerie.model_validate({"series": []})
+    assert ts.series == []
+
+
+# ---------------------------------------------------------------------------
+# Group C — MeterInfo structure
+# ---------------------------------------------------------------------------
+
+
+def test_meter_info_minimal_payload_parses() -> None:
+    """MeterInfo with only register_0 parses cleanly; optional fields default to None."""
+    model = MeterInfo.model_validate({"register_0": _MINIMAL_REGISTER_0})
+    assert model.reading.latest_read.full_read == 0.0
+    assert model.leak is None
+
+
+# ---------------------------------------------------------------------------
+# Group D — HistoricalData structure
+# ---------------------------------------------------------------------------
+
+
+def test_historical_data_full_parse() -> None:
+    """HistoricalData parses the anonymized fixture without errors."""
+    raw = Path("tests/mock_data/historical_data_mock_anonymized.json").read_text()
+    data = HistoricalData.model_validate(json.loads(raw))
+    assert len(data.timeseries) > 0
+    assert data.hit.meter_timezone
+
+
+def test_historical_data_missing_hit_raises() -> None:
+    """HistoricalData without required 'hit' field raises ValidationError."""
+    with pytest.raises(ValidationError):
+        HistoricalData.model_validate({"timeseries": _MINIMAL_TIMESERIES})
+
+
+def test_historical_data_missing_timeseries_raises() -> None:
+    """HistoricalData without required 'timeseries' field raises ValidationError."""
+    with pytest.raises(ValidationError):
+        HistoricalData.model_validate({"hit": _MINIMAL_HIT})
+
+
+# ---------------------------------------------------------------------------
+# Group E — Params model
+# ---------------------------------------------------------------------------
+
+
+def test_params_units_enum() -> None:
+    """Params with a valid units enum value round-trips to the correct EOWUnits member."""
+    p = Params.model_validate({"units": "GAL"})
+    assert p.units == EOWUnits.UNIT_GAL

--- a/tests/test_models_extensions.py
+++ b/tests/test_models_extensions.py
@@ -4,8 +4,8 @@ import json
 from pathlib import Path
 from typing import Any
 
-import pytest
 from pydantic import ValidationError
+import pytest
 
 from pyonwater.models import MeterInfo
 from pyonwater.models.eow_historical_models import (

--- a/tests/test_models_extensions.py
+++ b/tests/test_models_extensions.py
@@ -8,7 +8,12 @@ import pytest
 from pydantic import ValidationError
 
 from pyonwater.models import MeterInfo
-from pyonwater.models.eow_historical_models import HistoricalData, Hit, Params, TimeSerie
+from pyonwater.models.eow_historical_models import (
+    HistoricalData,
+    Hit,
+    Params,
+    TimeSerie,
+)
 from pyonwater.models.eow_models import Battery, Flags, LatestRead, Pwr
 from pyonwater.models.units import EOWUnits
 
@@ -168,7 +173,9 @@ def test_meter_info_minimal_payload_parses() -> None:
 
 def test_historical_data_full_parse() -> None:
     """HistoricalData parses the anonymized fixture without errors."""
-    raw = Path("tests/mock_data/historical_data_mock_anonymized.json").read_text()
+    raw = Path("tests/mock_data/historical_data_mock_anonymized.json").read_text(
+        encoding="utf-8"
+    )
     data = HistoricalData.model_validate(json.loads(raw))
     assert len(data.timeseries) > 0
     assert data.hit.meter_timezone

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -36,6 +36,11 @@ def test_deduce_native_unit():
         assert deduce_native_units(bad_unit)
 
 
+def test_deduce_native_unit_10_cf():
+    """UNIT_10_CF maps to NativeUnits.CF — previously untested branch."""
+    assert deduce_native_units(EOWUnits.UNIT_10_CF) == NativeUnits.CF
+
+
 def test_convert_units():
     """Test units conversion."""
     assert convert_to_native(NativeUnits.GAL, EOWUnits.UNIT_GAL, 1.0) == 1.0


### PR DESCRIPTION
## Summary

This PR is the test-improvement foundation for the recent `pyonwater` work.

- expands coverage for export-range historical data flow, CSV parsing, and meter-cache behavior
- broadens client discovery / fallback, token-expiration, model-validation, and unit-conversion coverage
- includes a small helper/type cleanup in the export-range path to keep the code strict-type clean and testable
- has been rebased onto the latest upstream `main` (`v0.3.32`)

## Verification

- `python -m pytest tests -q`
- `python -m pre_commit run --all-files`

## Follow-on stack

The next two branches build on this foundation:

- `submit/flexible-historical-data`
- `submit/at-a-glance`

## AI assistance disclosure

This PR was prepared with assistance from **GitHub Copilot (Goldeneye Preview)** for test drafting, diff review, and rebase verification. The final changes were reviewed and validated before submission.
